### PR TITLE
ar71xx: Fix mikrotik NAND compile problem

### DIFF
--- a/target/linux/ar71xx/files/drivers/mtd/nand/rb91x_nand.c
+++ b/target/linux/ar71xx/files/drivers/mtd/nand/rb91x_nand.c
@@ -438,7 +438,7 @@ static int rb91x_nand_remove(struct platform_device *pdev)
 {
 	struct rb91x_nand_info *info = platform_get_drvdata(pdev);
 
-	nand_release(&rbni->chip);
+	nand_release(&info->chip);
 
 	return 0;
 }


### PR DESCRIPTION
This fixes the following compile error:
drivers/mtd/nand/rb91x_nand.c: In function 'rb91x_nand_remove':
drivers/mtd/nand/rb91x_nand.c:445:16: error: 'rbni' undeclared (first use in this function)
  nand_release(&rbni->chip);

Fixes: 0f07496f520c ("kernel: Update kernel 4.9 to version 4.9.229")
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
(cherry picked from commit 66e04abbb6d0dec8642be5deb2fca4bba470f8ac)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
