### PR TITLE
mvebu: fix LAN/WAN port assignment on ClearFog Base/Pro

### DIFF
--- a/target/linux/mvebu/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/base-files/etc/board.d/02_network
@@ -50,16 +50,16 @@ marvell,axp-gp)
 	ucidef_set_interface_lan "eth0 eth1 eth2 eth3"
 	;;
 solidrun,clearfog*a1)
-	# eth0 is standalone ethernet
-	# eth1 is switch (-pro) or standalone ethernet (-base)
-	# eth2 is SFP
-	ucidef_set_interfaces_lan_wan "eth1" "eth0 eth2"
+	# eth2 is standalone ethernet
+	# eth0 is switch (-pro) or standalone ethernet (-base)
+	# eth1 is SFP
+	ucidef_set_interfaces_lan_wan "eth0" "eth2 eth1"
 
 	# if switch exists (clearfog-pro)
-	# switch port 5 is connected to eth1
+	# switch port 5 is connected to eth0
 	swconfig list 2>&1 | grep -q switch0 && \
 		ucidef_add_switch "switch0" \
-			"0:lan:5" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5u@eth1" "6:lan:6"
+			"0:lan:5" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5u@eth0" "6:lan:6"
 	;;
 *)
 	ucidef_set_interface_lan "eth0"


### PR DESCRIPTION
The comments in code already describe the intended lan / wan assignment:
lan: switch
wan: standalone ethernet and sfp

Update the interface handles to match the comments, as observed with
OpenWRT-19.07-rc2 on a Clearfog Pro Rev 2.0.

This also matches the effective assignment on master, while the actual
interface names (ethX) are different due to the reassignment in
06_set_iface_mac, which is included in 19.07 but was dropped for master.

Signed-off-by: Josua Mayer <josua.mayer@jm0.eu>
[extend commit message]
Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
