### PR TITLE
ath79: add support for TP-Link TL-WR710N v2.1

### DIFF
--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-8m.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-8m.dtsi
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9331_tplink_tl-wr710n.dtsi"
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				reg = <0x20000 0x7d0000>;
+				label = "firmware";
+			};
+
+			art: partition@7f0000 {
+				reg = <0x7f0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-v2.1.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-v2.1.dts
@@ -4,6 +4,6 @@
 #include "ar9331_tplink_tl-wr710n-8m.dtsi"
 
 / {
-	model = "TP-Link TL-WR710N v1";
-	compatible = "tplink,tl-wr710n-v1", "qca,ar9331";
+	model = "TP-Link TL-WR710N v2.1";
+	compatible = "tplink,tl-wr710n-v2.1", "qca,ar9331";
 };

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n.dtsi
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "tl-wr710n:green:system";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_usb_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&gpio {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+
+	dr_mode = "host";
+	vbus-supply = <&reg_usb_vbus>;
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -322,6 +322,17 @@ define Device/tplink_tl-wr710n-v1
 endef
 TARGET_DEVICES += tplink_tl-wr710n-v1
 
+define Device/tplink_tl-wr710n-v2.1
+  $(Device/tplink-8mlzma)
+  ATH_SOC := ar9331
+  DEVICE_TITLE := TP-Link TL-WR710N v2.1
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb-chipidea2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x07100002
+  TPLINK_HWREV := 0x2
+  SUPPORTED_DEVICES += tl-wr710n
+endef
+TARGET_DEVICES += tplink_tl-wr710n-v2.1
+
 define Device/tplink_tl-wr842n-v1
   $(Device/tplink-8m)
   ATH_SOC := ar7241


### PR DESCRIPTION
This adds support for the TP-Link TL-WR710N v2.1. It is basically a
re-issue of the v1.2.

Specifications:

SoC:       Atheros AR9331
CPU:       400 MHz
Flash:     8 MiB
RAM:       32 MiB
WiFi:      2.4 GHz b/g/n
Ethernet:  2x 100M ports
USB:       1x 2.0

The only difference from the v1 is the TP-Link hardware ID/revision.

Attention:
The TL-WR710N v2.0 (!) has only 4 MB flash and cannot be flashed with
this image. It has a different TPLINK_HWREV, so accidental flashing
of the factory image should be impossible without additional measures.

Unfortunately, the v2.0 in ar71xx has the same board name, so sysupgrade
from ar71xx v2.0 into ath79 v1/v2.1 will not be prevented, but will brick
the device.

Flashing instruction:

Upload the factory image via the OEM firmware GUI upgrade mechanism.

Further notes:

To make implementation easier if somebody desires to port the 4M v2.0,
this already creates two DTSI files.

Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
Tested-by: Fabian Eppig <fabian@eppig.de>
(backported from eb531337a779a48a2d17bc66f0d222325d6c1563)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
